### PR TITLE
Make `COPY ... REPLACING` case insensitive

### DIFF
--- a/src/main/java/io/proleap/cobol/preprocessor/sub/document/impl/CobolReplacementMapping.java
+++ b/src/main/java/io/proleap/cobol/preprocessor/sub/document/impl/CobolReplacementMapping.java
@@ -58,7 +58,7 @@ public class CobolReplacementMapping implements Comparable<CobolReplacementMappi
 				regexParts[i] = Pattern.quote(part);
 			}
 
-			result = String.join(regexSeparator, regexParts);
+			result = "(?i)" + String.join(regexSeparator, regexParts);
 		}
 
 		return result;


### PR DESCRIPTION
Hi! 

I've noticed that the `COPY ... REPLACING ...` statement  was not case insensitive. For example something like the following wouldn't have been replaced:

- PGM.cbl:
  ```cobol
  000000 IDENTIFICATION DIVISION.
  000000 PROGRAM-ID.  A.
  000000 DATA DIVISION.
  000000 WORKING-STORAGE SECTION.
  000000 COPY COPYBOOK REPLACING abc BY xyz.
  000000 PROCEDURE DIVISION.
  000000     GOBACK.
  000000 END PROGRAM a.
  ```

- COPYBOOK.cbl:
  ```cobol
  000000 01 ABC  PIC X(10).
  ```

With the provided commit the replacing step ignores case.