### PR TITLE
fix moveToStatement bug

### DIFF
--- a/src/main/antlr4/io/proleap/cobol/Cobol.g4
+++ b/src/main/antlr4/io/proleap/cobol/Cobol.g4
@@ -1669,7 +1669,7 @@ moveStatement
    ;
 
 moveToStatement
-   : moveToSendingArea TO identifier+
+   : moveToSendingArea TO (identifier ','?)+
    ;
 
 moveToSendingArea


### PR DESCRIPTION
Found that the TO list in moveToStatement needs to support comma separation
The new semantic is:
moveToStatement
   : moveToSendingArea TO (identifier ','?)+
   ;